### PR TITLE
chore: Claude Agent Swarm 설치

### DIFF
--- a/.github/scripts/janitor.py
+++ b/.github/scripts/janitor.py
@@ -6,6 +6,7 @@ to address the feedback, then commits and pushes the fixes.
 """
 
 import json
+import os
 import subprocess
 import sys
 
@@ -24,6 +25,14 @@ def run_git(*args) -> subprocess.CompletedProcess:
 
 def run_gh(*args) -> subprocess.CompletedProcess:
     return subprocess.run(["gh"] + list(args), capture_output=True, text=True, encoding="utf-8")
+
+
+def _set_output(key: str, value: str) -> None:
+    """Write a key=value pair to GITHUB_OUTPUT if available."""
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a", encoding="utf-8") as f:
+            f.write(f"{key}={value}\n")
 
 
 def _add_iteration_label(pr_number: int, iteration: int) -> None:
@@ -84,6 +93,7 @@ def main(pr_number: int) -> int:
             f"Janitor가 최대 수정 시도 횟수({max_retries}회)에 도달했습니다. "
             f"수동 개입이 필요합니다.\n\n---\nclaude-agent-swarm (janitor)에 의해 생성됨",
         )
+        _set_output("needs_rereview", "false")
         return 0
 
     current_iteration = iteration_count + 1
@@ -155,6 +165,7 @@ def main(pr_number: int) -> int:
                 f"PR #{pr_number}에 대한 리뷰 피드백을 찾을 수 없습니다.\n\n"
                 f"---\nclaude-agent-swarm (janitor)에 의해 생성됨",
             )
+            _set_output("needs_rereview", "false")
             return 0
 
     # --- Build prompt ---
@@ -222,6 +233,7 @@ def main(pr_number: int) -> int:
             f"({current_iteration}차 시도).\n\n"
             f"---\nclaude-agent-swarm (janitor)에 의해 생성됨",
         )
+        _set_output("needs_rereview", "false")
         return 0
 
     # --- Push (force to handle case where Claude already pushed) ---
@@ -240,6 +252,7 @@ def main(pr_number: int) -> int:
         f"---\nclaude-agent-swarm (janitor)에 의해 생성됨",
     )
 
+    _set_output("needs_rereview", "true")
     log.info("=== JANITOR COMPLETE === PR #%d - Fixes pushed (iteration %d)", pr_number, current_iteration)
     return 0
 

--- a/.github/workflows/agent-swarm.yml
+++ b/.github/workflows/agent-swarm.yml
@@ -117,6 +117,7 @@ jobs:
         run: gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-label "agent:fixing"
 
       - name: Run janitor agent
+        id: janitor
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python .github/scripts/janitor.py ${{ github.event.pull_request.number }}
@@ -128,6 +129,7 @@ jobs:
         run: gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --remove-label "agent:fixing"
 
       - name: Signal critic for re-review
+        if: steps.janitor.outputs.needs_rereview == 'true'
         env:
           GH_TOKEN: ${{ secrets.PAT }}
         run: gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-label "agent:need-review"


### PR DESCRIPTION
## 요약

Claude Agent Swarm 설정 파일과 워크플로우를 추가하는 PR입니다.

### 감지된 스택
- **언어:** Unknown

- **테스트 명령어:** `미설정`
- **린트 명령어:** `미설정`

### 추가되는 파일
- `.github/workflows/agent-swarm.yml` — GitHub Actions 워크플로우 (architect, critic, janitor)
- `.github/scripts/` — Python 에이전트 스크립트 및 프롬프트 템플릿
- `.agent-swarm/config.json` — 에이전트 설정
- `.agent-swarm/config.schema.json` — 설정 검증용 JSON 스키마
- `.agent-swarm/agents/` — 에이전트 규칙 및 스킬 (예제 파일 포함)

### 다음 단계
1. 이 PR을 리뷰하고 머지합니다
2. `claude-max` 라벨이 있는 self-hosted runner를 설정합니다
3. Runner에 필수 도구를 설치합니다: Python 3.8+, Claude CLI, GitHub CLI
4. 이슈를 생성하고 `agent:implement` 라벨을 추가하면 architect가 작업을 시작합니다

---
*Agent Swarm Dashboard에서 설치됨*