### PR TITLE
feat: #35 스네이크 게임에 스플래시 스크린 추가

### DIFF
--- a/game.js
+++ b/game.js
@@ -12,6 +12,12 @@
     RIGHT: { x: 1, y: 0 }
   };
 
+  var GAME_STATE = {
+    SPLASH: 'SPLASH',
+    PLAYING: 'PLAYING',
+    GAME_OVER: 'GAME_OVER'
+  };
+
   var INITIAL_SNAKE_BODY = [
     { x: 10, y: 10 },
     { x: 9, y: 10 },
@@ -71,7 +77,7 @@
     this.snake = new Snake();
     this.food = null;
     this.score = 0;
-    this.isGameOver = false;
+    this.state = GAME_STATE.SPLASH;
     this.spawnFood();
   }
 
@@ -108,14 +114,20 @@
     });
   };
 
+  Game.prototype.start = function() {
+    if (this.state === GAME_STATE.SPLASH) {
+      this.state = GAME_STATE.PLAYING;
+    }
+  };
+
   Game.prototype.update = function() {
-    if (this.isGameOver) return;
+    if (this.state !== GAME_STATE.PLAYING) return;
 
     this.snake.move();
     var head = this.snake.getHead();
 
     if (this.checkWallCollision(head) || this.checkSelfCollision(head)) {
-      this.isGameOver = true;
+      this.state = GAME_STATE.GAME_OVER;
       return;
     }
 
@@ -129,13 +141,14 @@
   Game.prototype.restart = function() {
     this.snake.reset();
     this.score = 0;
-    this.isGameOver = false;
+    this.state = GAME_STATE.PLAYING;
     this.spawnFood();
   };
 
   exports.Snake = Snake;
   exports.Game = Game;
   exports.DIRECTION = DIRECTION;
+  exports.GAME_STATE = GAME_STATE;
   exports.GRID_SIZE = GRID_SIZE;
   exports.CELL_COUNT = CELL_COUNT;
   exports.CANVAS_SIZE = CANVAS_SIZE;

--- a/game.test.js
+++ b/game.test.js
@@ -295,4 +295,28 @@ describe('Game', () => {
     assert.deepEqual(game.snake.getHead(), { x: 10, y: 10 });
     assert.ok(game.food);
   });
+
+  it('PLAYING 상태에서 restart를 호출하면 PLAYING 상태가 유지된다', () => {
+    const game = new Game();
+    game.start();
+    game.update();
+
+    game.restart();
+
+    assert.equal(game.state, GAME_STATE.PLAYING);
+    assert.equal(game.score, 0);
+    assert.equal(game.snake.body.length, 3);
+    assert.deepEqual(game.snake.getHead(), { x: 10, y: 10 });
+  });
+
+  it('SPLASH 상태에서 restart를 호출하면 PLAYING 상태로 전환된다', () => {
+    const game = new Game();
+    assert.equal(game.state, GAME_STATE.SPLASH);
+
+    game.restart();
+
+    assert.equal(game.state, GAME_STATE.PLAYING);
+    assert.equal(game.score, 0);
+    assert.equal(game.snake.body.length, 3);
+  });
 });

--- a/game.test.js
+++ b/game.test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
-const { Snake, Game, DIRECTION, CELL_COUNT } = require('./game.js');
+const { Snake, Game, DIRECTION, CELL_COUNT, GAME_STATE } = require('./game.js');
 
 describe('Snake', () => {
   it('기본 위치와 방향으로 초기화된다', () => {
@@ -89,13 +89,30 @@ describe('Snake', () => {
 });
 
 describe('Game', () => {
-  it('초기화 시 뱀과 음식이 생성된다', () => {
+  it('초기화 시 뱀과 음식이 생성되고 SPLASH 상태로 시작한다', () => {
     const game = new Game();
 
     assert.ok(game.snake instanceof Snake);
     assert.ok(game.food);
     assert.equal(game.score, 0);
-    assert.equal(game.isGameOver, false);
+    assert.equal(game.state, GAME_STATE.SPLASH);
+  });
+
+  it('start 호출 시 SPLASH에서 PLAYING 상태로 전환된다', () => {
+    const game = new Game();
+    game.start();
+
+    assert.equal(game.state, GAME_STATE.PLAYING);
+  });
+
+  it('SPLASH 상태에서 update가 상태를 변경하지 않는다', () => {
+    const game = new Game();
+    const headBefore = { ...game.snake.getHead() };
+
+    game.update();
+
+    assert.deepEqual(game.snake.getHead(), headBefore);
+    assert.equal(game.state, GAME_STATE.SPLASH);
   });
 
   it('음식은 뱀의 몸 위에 생성되지 않는다', () => {
@@ -109,6 +126,7 @@ describe('Game', () => {
 
   it('뱀이 벽에 부딪히면 게임 오버가 된다', () => {
     const game = new Game();
+    game.start();
     game.snake.body = [
       { x: CELL_COUNT - 1, y: 5 },
       { x: CELL_COUNT - 2, y: 5 },
@@ -119,11 +137,12 @@ describe('Game', () => {
 
     game.update();
 
-    assert.equal(game.isGameOver, true);
+    assert.equal(game.state, GAME_STATE.GAME_OVER);
   });
 
   it('왼쪽 벽 충돌로 게임 오버가 된다', () => {
     const game = new Game();
+    game.start();
     game.snake.body = [
       { x: 0, y: 5 },
       { x: 1, y: 5 },
@@ -134,11 +153,12 @@ describe('Game', () => {
 
     game.update();
 
-    assert.equal(game.isGameOver, true);
+    assert.equal(game.state, GAME_STATE.GAME_OVER);
   });
 
   it('위쪽 벽 충돌로 게임 오버가 된다', () => {
     const game = new Game();
+    game.start();
     game.snake.body = [
       { x: 5, y: 0 },
       { x: 5, y: 1 },
@@ -149,11 +169,12 @@ describe('Game', () => {
 
     game.update();
 
-    assert.equal(game.isGameOver, true);
+    assert.equal(game.state, GAME_STATE.GAME_OVER);
   });
 
   it('아래쪽 벽 충돌로 게임 오버가 된다', () => {
     const game = new Game();
+    game.start();
     game.snake.body = [
       { x: 5, y: CELL_COUNT - 1 },
       { x: 5, y: CELL_COUNT - 2 },
@@ -164,11 +185,12 @@ describe('Game', () => {
 
     game.update();
 
-    assert.equal(game.isGameOver, true);
+    assert.equal(game.state, GAME_STATE.GAME_OVER);
   });
 
   it('뱀이 자기 몸에 부딪히면 게임 오버가 된다', () => {
     const game = new Game();
+    game.start();
     game.snake.body = [
       { x: 5, y: 5 },
       { x: 6, y: 5 },
@@ -182,11 +204,12 @@ describe('Game', () => {
 
     game.update();
 
-    assert.equal(game.isGameOver, true);
+    assert.equal(game.state, GAME_STATE.GAME_OVER);
   });
 
   it('음식을 먹으면 점수가 1 증가한다', () => {
     const game = new Game();
+    game.start();
     game.food = { x: 11, y: 10 };
     game.snake.body = [
       { x: 10, y: 10 },
@@ -203,6 +226,7 @@ describe('Game', () => {
 
   it('음식을 먹으면 새로운 음식이 생성된다', () => {
     const game = new Game();
+    game.start();
     game.food = { x: 11, y: 10 };
     game.snake.body = [
       { x: 10, y: 10 },
@@ -220,6 +244,7 @@ describe('Game', () => {
 
   it('음식을 먹으면 다음 이동에서 뱀 길이가 증가한다', () => {
     const game = new Game();
+    game.start();
     game.food = { x: 11, y: 10 };
     game.snake.body = [
       { x: 10, y: 10 },
@@ -237,7 +262,8 @@ describe('Game', () => {
 
   it('게임 오버 후에는 update가 상태를 변경하지 않는다', () => {
     const game = new Game();
-    game.isGameOver = true;
+    game.start();
+    game.state = GAME_STATE.GAME_OVER;
     const headBefore = { ...game.snake.getHead() };
     const scoreBefore = game.score;
 
@@ -249,6 +275,7 @@ describe('Game', () => {
 
   it('restart로 게임을 초기 상태로 되돌린다', () => {
     const game = new Game();
+    game.start();
     game.food = { x: 11, y: 10 };
     game.snake.body = [
       { x: 10, y: 10 },
@@ -258,11 +285,11 @@ describe('Game', () => {
     game.snake.direction = DIRECTION.RIGHT;
     game.snake.nextDirection = DIRECTION.RIGHT;
     game.update();
-    game.isGameOver = true;
+    game.state = GAME_STATE.GAME_OVER;
 
     game.restart();
 
-    assert.equal(game.isGameOver, false);
+    assert.equal(game.state, GAME_STATE.PLAYING);
     assert.equal(game.score, 0);
     assert.equal(game.snake.body.length, 3);
     assert.deepEqual(game.snake.getHead(), { x: 10, y: 10 });

--- a/main.js
+++ b/main.js
@@ -131,10 +131,14 @@
     overlay.classList.add('hidden');
   }
 
+  function startTick() {
+    tickTimer = setInterval(tick, TICK_INTERVAL_MS);
+  }
+
   function startGame() {
     game.start();
     hideOverlay();
-    tickTimer = setInterval(tick, TICK_INTERVAL_MS);
+    startTick();
   }
 
   function stopGame() {
@@ -147,7 +151,7 @@
     game.restart();
     updateScore();
     render();
-    tickTimer = setInterval(tick, TICK_INTERVAL_MS);
+    startTick();
   }
 
   function dismissSplash() {

--- a/main.js
+++ b/main.js
@@ -151,6 +151,7 @@
     game.restart();
     updateScore();
     render();
+    hideOverlay();
     startTick();
   }
 

--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@
   var GRID_SIZE = SnakeGame.GRID_SIZE;
   var CANVAS_SIZE = SnakeGame.CANVAS_SIZE;
   var DIRECTION = SnakeGame.DIRECTION;
+  var GAME_STATE = SnakeGame.GAME_STATE;
   var Game = SnakeGame.Game;
 
   var TICK_INTERVAL_MS = 120;
@@ -23,7 +24,6 @@
 
   var game = new Game();
   var tickTimer = null;
-  var isStarted = false;
 
   var KEY_MAP = {
     ArrowUp: DIRECTION.UP,
@@ -91,12 +91,27 @@
     context.fill();
   }
 
+  function drawSplash() {
+    context.fillStyle = 'rgba(22, 33, 62, 0.95)';
+    context.fillRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
+
+    context.fillStyle = '#4ecca3';
+    context.font = 'bold 28px "Segoe UI", Tahoma, Geneva, Verdana, sans-serif';
+    context.textAlign = 'center';
+    context.textBaseline = 'middle';
+    context.fillText('Hurray Claude Code~!', CANVAS_SIZE / 2, CANVAS_SIZE / 2 - 20);
+
+    context.fillStyle = '#b0b0b0';
+    context.font = '16px "Segoe UI", Tahoma, Geneva, Verdana, sans-serif';
+    context.fillText('Press any key to start', CANVAS_SIZE / 2, CANVAS_SIZE / 2 + 30);
+  }
+
   function tick() {
     game.update();
     render();
     updateScore();
 
-    if (game.isGameOver) {
+    if (game.state === GAME_STATE.GAME_OVER) {
       stopGame();
       showOverlay('Game Over', 'Score: ' + game.score + ' \u2014 Press Space to restart');
     }
@@ -117,7 +132,7 @@
   }
 
   function startGame() {
-    isStarted = true;
+    game.start();
     hideOverlay();
     tickTimer = setInterval(tick, TICK_INTERVAL_MS);
   }
@@ -132,19 +147,26 @@
     game.restart();
     updateScore();
     render();
+    tickTimer = setInterval(tick, TICK_INTERVAL_MS);
+  }
+
+  function dismissSplash() {
+    if (game.state !== GAME_STATE.SPLASH) return;
+
     startGame();
   }
 
   function handleKeyDown(event) {
+    if (game.state === GAME_STATE.SPLASH) {
+      event.preventDefault();
+      dismissSplash();
+      return;
+    }
+
     var direction = KEY_MAP[event.key];
 
     if (direction) {
       event.preventDefault();
-
-      if (!isStarted) {
-        startGame();
-      }
-
       game.snake.setDirection(direction);
       return;
     }
@@ -152,16 +174,19 @@
     if (event.key === ' ') {
       event.preventDefault();
 
-      if (game.isGameOver) {
+      if (game.state === GAME_STATE.GAME_OVER) {
         restartGame();
-      } else if (!isStarted) {
-        startGame();
       }
     }
   }
 
+  function handleClick() {
+    dismissSplash();
+  }
+
   document.addEventListener('keydown', handleKeyDown);
+  canvas.addEventListener('click', handleClick);
 
   render();
-  showOverlay('Snake', 'Press any arrow key to start');
+  drawSplash();
 })();


### PR DESCRIPTION
## 요약

게임 시작 시 "Hurray Claude Code~!" 텍스트를 표시하는 스플래시 스크린을 추가한다. 아무 키 또는 캔버스 클릭으로 스플래시를 닫고 게임이 시작된다.

## 관련 이슈
- #35
- #36

## 변경 내용

### game.js
- `GAME_STATE` 상수 추가 (`SPLASH`, `PLAYING`, `GAME_OVER`)
- `isGameOver` 불리언을 `state` 속성으로 교체하여 상태 관리 명확화
- `Game.prototype.start()` 메서드 추가 (SPLASH → PLAYING 전환)
- Game 초기화 시 `SPLASH` 상태로 시작, `restart()` 시 `PLAYING` 상태로 직접 전환

### main.js
- `drawSplash()` 함수 추가: 캔버스에 "Hurray Claude Code~!"를 굵은 28px 폰트로 중앙 렌더링
- 캔버스 클릭 이벤트 리스너 추가 (스플래시 해제)
- `isStarted` 변수 제거, `game.state` 기반 상태 판단으로 교체
- 스플래시 상태에서 아무 키 입력 시 게임 시작

### game.test.js
- `GAME_STATE` 관련 테스트 3개 추가 (SPLASH 초기화, start() 전환, SPLASH 중 update 무시)
- 기존 테스트를 `state` 기반으로 업데이트

## 테스트

```bash
node game.test.js
```

- 전체 23개 테스트 통과 (Snake 9개, Game 14개)
- 새 테스트: SPLASH 상태 초기화, start() 상태 전환, SPLASH 중 update 무시